### PR TITLE
[bugfix] change protocol to 'wss://' if request was secure

### DIFF
--- a/lib/Dancer2/Plugin/WebSocket.pm
+++ b/lib/Dancer2/Plugin/WebSocket.pm
@@ -54,7 +54,8 @@ has connections => (
 sub websocket_url :PluginKeyword {
     my $self = shift;
     my $request = $self->app->request;
-    my $address = 'ws://' . $request->host . $self->mount_path;
+    my $proto = $request->secure ? 'wss://' : 'ws://';
+    my $address = $proto . $request->host . $self->mount_path;
 
     return $address;
 }


### PR DESCRIPTION
Without This patch you get an error message in the debugging console of firefox, which says:

SecurityError: The operation is insecure.

This patch changes protocol from ws:// to wss:// if the request->secure is true

